### PR TITLE
Fix concurrency issues by locking critical sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 effidict/_version.py
 docs/_build
 .vscode/
+venv
+.venv

--- a/effidict/disk_backend.py
+++ b/effidict/disk_backend.py
@@ -1,5 +1,6 @@
 import time
 from abc import abstractmethod
+from threading import Lock
 import sqlite3  
 import json
 import os
@@ -17,6 +18,7 @@ except Exception:
 class DiskBackend:
     def __init__(self, storage_path):
         self.storage_path = storage_path + f"{int(time.time())}_{id(self)}"
+        self.storage_lock = Lock()
         
     @abstractmethod
     def serialize(self, key, value):
@@ -46,7 +48,7 @@ class DiskBackend:
 class SqliteBackend(DiskBackend):
     def __init__(self, storage_path):
         super().__init__(storage_path)
-        self.conn = sqlite3.connect(self.storage_path)
+        self.conn = sqlite3.connect(self.storage_path, check_same_thread=False)
         self.cursor = self.conn.cursor()
         self.cursor.execute(
             "CREATE TABLE IF NOT EXISTS data (key TEXT PRIMARY KEY, value TEXT)"
@@ -54,65 +56,76 @@ class SqliteBackend(DiskBackend):
 
     def serialize(self, key, value):
         json_value = json.dumps(value)
-        self.cursor.execute(
-            "REPLACE INTO data (key, value) VALUES (?, ?)", (key, json_value)
-        )
-        self.conn.commit()
+        with self.storage_lock:
+            self.cursor.execute(
+                "REPLACE INTO data (key, value) VALUES (?, ?)", (key, json_value)
+            )
+            self.conn.commit()
 
     def deserialize(self, key):
-        self.cursor.execute("SELECT value FROM data WHERE key=?", (key,))
-        result = self.cursor.fetchone()
+        with self.storage_lock:
+            self.cursor.execute("SELECT value FROM data WHERE key=?", (key,))
+            result = self.cursor.fetchone()
         if result:
             return json.loads(result[0])
         raise KeyError(key)
     
     def del_item(self, key):
-        self.cursor.execute("DELETE FROM data WHERE key=?", (key,))
-        self.conn.commit()
+        with self.storage_lock:
+            self.cursor.execute("DELETE FROM data WHERE key=?", (key,))
+            self.conn.commit()
 
     def keys(self):
-        self.cursor.execute("SELECT key FROM data")
-        return [key[0] for key in self.cursor.fetchall()]
+        with self.storage_lock:
+            self.cursor.execute("SELECT key FROM data")
+            return [key[0] for key in self.cursor.fetchall()]
     
     def load_from_dict(self, dictionary):
-        with self.conn:
-            items_to_insert = [
-                (key, json.dumps(value)) for key, value in dictionary.items()
-            ]
-            self.cursor.executemany(
-                "REPLACE INTO data (key, value) VALUES (?, ?)",
-                items_to_insert,
-            )
+        items_to_insert = [
+            (key, json.dumps(value)) for key, value in dictionary.items()
+        ]
+        with self.storage_lock:
+            with self.conn:
+                self.cursor.executemany(
+                    "REPLACE INTO data (key, value) VALUES (?, ?)",
+                    items_to_insert,
+                )
 
     def destroy(self):
         self.conn.close()
         os.remove(self.storage_path)
 
 
+# Since each key is stored separately, Locking is not the fastest solution here.
+# However, it ensures thread safety for file for the same keys.
 class PickleBackend(DiskBackend):
     def __init__(self, storage_path):
         super().__init__(storage_path)
         os.makedirs(self.storage_path, exist_ok=True)
 
     def serialize(self, key, value):
-        with open(os.path.join(self.storage_path, key), "wb") as f:
-            pickle.dump(value, f)
+        with self.storage_lock:
+            with open(os.path.join(self.storage_path, key), "wb") as f:
+                pickle.dump(value, f)
 
     def deserialize(self, key):
-        try:
-            with open(os.path.join(self.storage_path, key), "rb") as f:
-                return pickle.load(f)
-        except FileNotFoundError:
-            raise KeyError(key)
+        with self.storage_lock:
+            try:
+                with open(os.path.join(self.storage_path, key), "rb") as f:
+                    return pickle.load(f)
+            except FileNotFoundError:
+                raise KeyError(key)
         
     def del_item(self, key):
-        try:
-            os.remove(os.path.join(self.storage_path, key))
-        except FileNotFoundError:
-            pass
+        with self.storage_lock:
+            try:
+                os.remove(os.path.join(self.storage_path, key))
+            except FileNotFoundError:
+                pass
 
     def keys(self):
-        return os.listdir(self.storage_path)
+        with self.storage_lock:
+            return os.listdir(self.storage_path)
 
     def destroy(self):
         shutil.rmtree(self.storage_path)
@@ -129,57 +142,62 @@ class Hdf5Backend(DiskBackend):
         """
         Store data and its Python type as an HDF5 attribute.
         """
-        if key in self.file:
-            del self.file[key] 
+        with self.storage_lock:
+            if key in self.file:
+                del self.file[key] 
 
-        type_name = type(value).__name__
-        
-        if value is None:
-            ds = self.file.create_dataset(key, data=h5py.Empty("f"))
-        elif isinstance(value, (dict, list, tuple)):
-            ds = self.file.create_dataset(key, data=repr(value))
-        else:
-            ds = self.file.create_dataset(key, data=value)
+            type_name = type(value).__name__
             
-        ds.attrs['python_type'] = type_name
+            if value is None:
+                ds = self.file.create_dataset(key, data=h5py.Empty("f"))
+            elif isinstance(value, (dict, list, tuple)):
+                ds = self.file.create_dataset(key, data=repr(value))
+            else:
+                ds = self.file.create_dataset(key, data=value)
+            
+            ds.attrs['python_type'] = type_name
 
     def deserialize(self, key):
         """
         Read data and use the 'python_type' attribute to cast it back correctly.
         """
         try:
-            dataset = self.file[key]
-            type_name = dataset.attrs.get('python_type')
+            with self.storage_lock:
+                dataset = self.file[key]
+                type_name = dataset.attrs.get('python_type')
 
-            if type_name is None:
-                raise TypeError(f"Dataset for key '{key}' is missing 'python_type' attribute.")
+                if type_name is None:
+                    raise TypeError(f"Dataset for key '{key}' is missing 'python_type' attribute.")
 
-            if type_name == 'NoneType':
-                return None
-            elif type_name in ('dict', 'list', 'tuple'):
-                str_data = dataset.asstr()[()]
-                return ast.literal_eval(str_data)
-            elif type_name == 'str':
-                return dataset.asstr()[()]
-            else: 
-                return dataset[()]
+                if type_name == 'NoneType':
+                    return None
+                elif type_name in ('dict', 'list', 'tuple'):
+                    str_data = dataset.asstr()[()]
+                    return ast.literal_eval(str_data)
+                elif type_name == 'str':
+                    return dataset.asstr()[()]
+                else: 
+                    return dataset[()]
 
         except KeyError:
             raise KeyError(key)
         
     def del_item(self, key):
         try:
-            del self.file[key]
+            with self.storage_lock:
+                del self.file[key]
         except KeyError:
             pass
 
     def keys(self):
-        return list(self.file.keys())
+        with self.storage_lock:
+            return list(self.file.keys())
     
     def destroy(self):
         self.file.close()
         os.remove(self.storage_path)    
 
+# Similarly to pickle, locking is not the most efficient here.
 class JSONBackend(DiskBackend):
     def __init__(self, storage_path):
         super().__init__(storage_path)
@@ -189,19 +207,22 @@ class JSONBackend(DiskBackend):
         return os.path.join(self.storage_path, f"{key}.json")
 
     def serialize(self, key, value):
-        with open(self._file_path(key), "w") as f:
-            json.dump(value, f)
+        with self.storage_lock:
+            with open(self._file_path(key), "w") as f:
+                json.dump(value, f)
 
     def deserialize(self, key):
         try:
-            with open(self._file_path(key), "r") as f:
-                return json.load(f)
+            with self.storage_lock:
+                with open(self._file_path(key), "r") as f:
+                    return json.load(f)
         except FileNotFoundError:
             raise KeyError(key)
         
     def del_item(self, key):
         try:
-            os.remove(self._file_path(key))
+            with self.storage_lock:
+                os.remove(self._file_path(key))
         except FileNotFoundError:
             pass
 

--- a/effidict/effidict.py
+++ b/effidict/effidict.py
@@ -3,7 +3,6 @@ class EffiDict:
         self.max_in_memory = max_in_memory
         self.disk_backend = disk_backend
         self.replacement_strategy = replacement_strategy
-        self.memory = replacement_strategy.memory
 
     def __enter__(self):
         return self
@@ -35,30 +34,23 @@ class EffiDict:
             yield self[key]
 
     def __contains__(self, key):
-        return key in self.memory or (self.disk_backend and key in self.disk_backend.keys())
+        return key in self.replacement_strategy or (
+            self.disk_backend and key in self.disk_backend.keys()
+        )
 
     def pop(self, key, default=None):
         try:
-            value = self.memory.pop(key)
-        except KeyError:
-            if key in self.keys():
-                value = self[key]
-                self.__delitem__(key)
-            else:
-                return default
-
-        return value
+            return self.replacement_strategy.get(key)
+        except KeyError:  # key not in memory & disk
+            return default
+        finally:
+            self.delete(key)
 
     def clear(self):
-        all_keys = self.keys()
-        self.memory.clear()
+        # already calls super().clear() internally
+        self.replacement_strategy.clear()
         if self.disk_backend:
-            for key in all_keys:
-                self.disk_backend.del_item(key)
-        # Also clear strategy-specific caches like LFU/MFU counts
-        if hasattr(self.replacement_strategy, 'clear'):
-            self.replacement_strategy.clear()
-
+            self.disk_backend.clear()
 
     def __del__(self):
         try:
@@ -80,8 +72,10 @@ class EffiDict:
 
     def keys(self):
         """Return a list of all unique keys known to the dictionary (memory + disk)."""
-        mem_keys = set(self.memory.keys())
-        disk_keys = set(self.disk_backend.keys() if self.disk_backend is not None else [])
+        mem_keys = set(self.replacement_strategy.keys())
+        disk_keys = set(
+            self.disk_backend.keys() if self.disk_backend is not None else []
+        )
         return list(mem_keys.union(disk_keys))
 
     def __getitem__(self, key):
@@ -90,14 +84,18 @@ class EffiDict:
     def __setitem__(self, key, value):
         self.replacement_strategy.put(key, value)
 
+    def delete(self, key):
+        # The strategy handles its own memory (and secondary_memory for LFU/MFU)
+        self.replacement_strategy.delete(key)
+        # Ensure it's also removed from the disk backend
+        if self.disk_backend:
+            self.disk_backend.del_item(key)
+
     def __delitem__(self, key):
         # Check existence first to raise KeyError properly
         if key not in self:
             raise KeyError(key)
-        # The strategy handles its own memory (and secondary_memory for LFU/MFU)
-        self.replacement_strategy.delete(key)
-        # Ensure it's also removed from the disk backend
-        self.disk_backend.del_item(key)
+        self.delete(key)
 
     def load_from_dict(self, dictionary):
         self.disk_backend.load_from_dict(dictionary)

--- a/effidict/effidict.py
+++ b/effidict/effidict.py
@@ -16,11 +16,7 @@ class EffiDict:
             self.disk_backend.destroy()
 
     def __iter__(self):
-        self._iter_keys = iter(self.keys())
-        return self
-
-    def __next__(self):
-        return next(self._iter_keys)
+        return iter(self.keys())
 
     def __len__(self):
         return len(self.keys())

--- a/effidict/replacement_strategies.py
+++ b/effidict/replacement_strategies.py
@@ -1,12 +1,15 @@
-from collections import OrderedDict, defaultdict
 import random
 from abc import abstractmethod
+from collections import OrderedDict, defaultdict
+from threading import Lock
+
 
 class ReplacementStrategy:
     def __init__(self, disk_backend, max_in_memory):
         self.memory = self.get_memory()
         self.disk_backend = disk_backend
         self.max_in_memory = max_in_memory
+        self.memory_lock = Lock()
 
     @abstractmethod
     def get(self, key):
@@ -15,144 +18,215 @@ class ReplacementStrategy:
     @abstractmethod
     def put(self, key, value):
         pass
-    
+
     @abstractmethod
     def get_memory(self):
         pass
-        
-    
+
+    def __contains__(self, key):
+        # When GIL is held, in is thread safe and no lock is needed
+        return key in self.memory
+
     # --- NEW: Method for handling deletion from memory ---
     def delete(self, key):
         """Remove a key from internal memory structures."""
-        if key in self.memory:
-            del self.memory[key]
+        with self.memory_lock:
+            if key in self.memory:
+                del self.memory[key]
 
     def clear(self):
         """Clear internal memory structures."""
-        self.memory.clear()
+        with self.memory_lock:
+            self.memory.clear()
+
+    def pop(self, key):
+        with self.memory_lock:
+            value = self.memory[key]
+            del self.memory[key]
+            return value
+
+    def keys(self):
+        with self.memory_lock:
+            return self.memory.keys()
+
 
 class RandomReplacement(ReplacementStrategy):
     def get(self, key):
-        if key in self.memory:
-            return self.memory[key]
-        else:
-            return self.disk_backend.deserialize(key)
+        with self.memory_lock:
+            if key in self.memory:
+                return self.memory[key]
+
+        # else:
+        return self.disk_backend.deserialize(key)
 
     def put(self, key, value):
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            random_key = random.choice(list(self.memory.keys()))
-            random_value = self.memory.pop(random_key)
-            self.disk_backend.serialize(random_key, random_value)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.memory[key] = value
+            if len(self.memory) > self.max_in_memory:
+                random_key = random.choice(list(self.memory.keys()))
+                random_value = self.memory.pop(random_key)
+
+                to_serialize = (random_key, random_value)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return defaultdict()
-    
+
+
 class FIFOReplacement(ReplacementStrategy):
     def get(self, key):
-        if key in self.memory:
-            return self.memory[key]
-        else:
-            return self.disk_backend.deserialize(key)
-        
+        with self.memory_lock:
+            if key in self.memory:
+                return self.memory[key]
+
+        return self.disk_backend.deserialize(key)
+
     def put(self, key, value):
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            oldest_key, oldest_value = self.memory.popitem(last=False)
-            self.disk_backend.serialize(oldest_key, oldest_value)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.memory[key] = value
+            if len(self.memory) > self.max_in_memory:
+                oldest_key, oldest_value = self.memory.popitem(last=False)
+                to_serialize = (oldest_key, oldest_value)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return OrderedDict()
-    
+
+
 class LIFOReplacement(ReplacementStrategy):
     def get(self, key):
-        if key in self.memory:
-            return self.memory[key]
-        else:
-            return self.disk_backend.deserialize(key)
-        
+        with self.memory_lock:
+            if key in self.memory:
+                return self.memory[key]
+
+        return self.disk_backend.deserialize(key)
+
     def put(self, key, value):
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            oldest_key, oldest_value = self.memory.popitem()
-            self.disk_backend.serialize(oldest_key, oldest_value)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.memory[key] = value
+            if len(self.memory) > self.max_in_memory:
+                oldest_key, oldest_value = self.memory.popitem()
+                to_serialize = (oldest_key, oldest_value)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return OrderedDict()
-    
+
+
 class LRUReplacement(ReplacementStrategy):
     def get(self, key):
-        if key in self.memory:
-            self.memory.move_to_end(key)
-            return self.memory[key]
-        else:
-            value = self.disk_backend.deserialize(key)
-            if value is not None:
-                self.put(key, value)
-            return value
-        
+        with self.memory_lock:
+            if key in self.memory:
+                self.memory.move_to_end(key)
+                return self.memory[key]
+
+        value = self.disk_backend.deserialize(key)
+
+        if value is not None:
+            self.put(key, value)
+
+        return value
+
     def put(self, key, value):
-        self.memory[key] = value
-        self.memory.move_to_end(key)
-        if len(self.memory) > self.max_in_memory:
-            oldest_key, oldest_value = self.memory.popitem(last=False)
-            self.disk_backend.serialize(oldest_key, oldest_value)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.memory[key] = value
+            self.memory.move_to_end(key)
+            if len(self.memory) > self.max_in_memory:
+                oldest_key, oldest_value = self.memory.popitem(last=False)
+                to_serialize = (oldest_key, oldest_value)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return OrderedDict()
-    
+
+
 class MRUReplacement(ReplacementStrategy):
     def get(self, key):
-        if key in self.memory:
-            self.memory.move_to_end(key)
-            return self.memory[key]
-        else:
-            value = self.disk_backend.deserialize(key)
-            if value is not None:
-                self.put(key, value)
-            return value
-        
+        with self.memory_lock:
+            if key in self.memory:
+                self.memory.move_to_end(key)
+                return self.memory[key]
+
+        value = self.disk_backend.deserialize(key)
+
+        if value is not None:
+            self.put(key, value)
+
+        return value
+
     def put(self, key, value):
-        self.memory[key] = value
-        self.memory.move_to_end(key)
-        if len(self.memory) > self.max_in_memory:
-            oldest_key, oldest_value = self.memory.popitem()
-            self.disk_backend.serialize(oldest_key, oldest_value)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.memory[key] = value
+            self.memory.move_to_end(key)
+            if len(self.memory) > self.max_in_memory:
+                oldest_key, oldest_value = self.memory.popitem()
+                to_serialize = (oldest_key, oldest_value)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return OrderedDict()
-    
+
+
 class LFUReplacement(ReplacementStrategy):
     def __init__(self, disk_backend, max_in_memory):
         super().__init__(disk_backend, max_in_memory)
         self.secondary_memory = defaultdict(int)
 
     def get(self, key):
-        if key in self.memory:
-            self.secondary_memory[key] += 1
-            return self.memory[key]
-        else:
-            value = self.disk_backend.deserialize(key)
-            self.put(key, value) # simplified: put handles loading
-            return value
-        
+        with self.memory_lock:
+            if key in self.memory:
+                self.secondary_memory[key] += 1
+                return self.memory[key]
+
+        value = self.disk_backend.deserialize(key)
+        self.put(key, value)  # simplified: put handles loading
+        return value
+
     def put(self, key, value):
-        # Increment frequency if key exists, otherwise set to 1
-        self.secondary_memory[key] = self.secondary_memory.get(key, 0) + 1
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            # Find the key with the minimum frequency to evict
-            # Exclude the key we just added from eviction candidates
-            eviction_candidates = {k: v for k, v in self.secondary_memory.items() if k != key}
-            if eviction_candidates:
-                min_key = min(eviction_candidates, key=eviction_candidates.get)
-                min_value = self.memory.pop(min_key)
-                self.disk_backend.serialize(min_key, min_value)
-                del self.secondary_memory[min_key]
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            # Increment frequency if key exists, otherwise set to 1
+            self.secondary_memory[key] = self.secondary_memory.get(key, 0) + 1
+            self.memory[key] = value
+            if len(self.memory) > self.max_in_memory:
+                # Find the key with the minimum frequency to evict
+                # Exclude the key we just added from eviction candidates
+                eviction_candidates = {
+                    k: v for k, v in self.secondary_memory.items() if k != key
+                }
+                if eviction_candidates:
+                    min_key = min(eviction_candidates, key=eviction_candidates.get)
+                    min_value = self.memory.pop(min_key)
+                    to_serialize = (min_key, min_value)
+                    del self.secondary_memory[min_key]
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
-        return {} # Plain dict is fine here
-    
+        return {}  # Plain dict is fine here
+
     # --- OVERRIDE: Also clean up the frequency counter ---
     def delete(self, key):
         super().delete(key)
@@ -163,67 +237,51 @@ class LFUReplacement(ReplacementStrategy):
         super().clear()
         self.secondary_memory.clear()
 
+
 # Similar changes for MFUReplacement...
 class MFUReplacement(ReplacementStrategy):
-    def __init__(self, disk_backend, max_in_memory):
-        super().__init__(disk_backend, max_in_memory)
-        self.secondary_memory = defaultdict(int)
-
-    def get(self, key):
-        if key in self.memory:
-            self.secondary_memory[key] += 1
-            return self.memory[key]
-        else:
-            value = self.disk_backend.deserialize(key)
-            self.put(key, value)
-            return value
-        
-    def put(self, key, value):
-        self.secondary_memory[key] = self.secondary_memory.get(key, 0) + 1
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            eviction_candidates = {k: v for k, v in self.secondary_memory.items() if k != key}
-            if eviction_candidates:
-                max_key = max(eviction_candidates, key=eviction_candidates.get)
-                max_value = self.memory.pop(max_key)
-                self.disk_backend.serialize(max_key, max_value)
-                del self.secondary_memory[max_key]
-
-    def get_memory(self):
-        return {}
-    
     def delete(self, key):
-        super().delete(key)
-        if key in self.secondary_memory:
-            del self.secondary_memory[key]
+        with self.memory_lock:
+            if key in self.memory:
+                del self.memory[key]
+            if key in self.secondary_memory:
+                del self.secondary_memory[key]
 
     def clear(self):
-        super().clear()
-        self.secondary_memory.clear()
-
+        with self.memory_lock:
+            self.memory.clear()
+            self.secondary_memory.clear()
 
     def __init__(self, disk_backend, max_in_memory):
         super().__init__(disk_backend, max_in_memory)
         self.secondary_memory = defaultdict(int)
 
     def get(self, key):
-        if key in self.memory:
-            self.secondary_memory[key] += 1
-            return self.memory[key]
-        else:
-            value = self.disk_backend.deserialize(key)
-            if value is not None:
-                self.put(key, value)
-            return value
-        
+        with self.memory_lock:
+            if key in self.memory:
+                self.secondary_memory[key] += 1
+                return self.memory[key]
+
+        value = self.disk_backend.deserialize(key)
+
+        if value is not None:
+            self.put(key, value)
+        return value
+
     def put(self, key, value):
-        self.secondary_memory[key] = 1
-        self.memory[key] = value
-        if len(self.memory) > self.max_in_memory:
-            max_key = max(self.secondary_memory, key=self.secondary_memory.get)
-            max_value = self.memory.pop(max_key)
-            self.disk_backend.serialize(max_key, max_value)
-            self.secondary_memory.pop(max_key)
+        to_serialize = None  # ensures memory/backend lock separation
+
+        with self.memory_lock:
+            self.secondary_memory[key] = 1
+            self.memory[key] = value
+            if len(self.memory) > self.max_in_memory:
+                max_key = max(self.secondary_memory, key=self.secondary_memory.get)
+                max_value = self.memory.pop(max_key)
+                to_serialize = (max_key, max_value)
+                self.secondary_memory.pop(max_key)
+
+        if to_serialize:
+            self.disk_backend.serialize(*to_serialize)
 
     def get_memory(self):
         return OrderedDict()

--- a/effidict/replacement_strategies.py
+++ b/effidict/replacement_strategies.py
@@ -24,7 +24,7 @@ class ReplacementStrategy:
         pass
 
     def __contains__(self, key):
-        # When GIL is held, in is thread safe and no lock is needed
+        # When GIL is held, "in" is thread safe and no lock is needed
         return key in self.memory
 
     # --- NEW: Method for handling deletion from memory ---
@@ -47,7 +47,8 @@ class ReplacementStrategy:
 
     def keys(self):
         with self.memory_lock:
-            return self.memory.keys()
+            # view might not be thread safe
+            return set(self.memory.keys()) 
 
 
 class RandomReplacement(ReplacementStrategy):
@@ -227,16 +228,17 @@ class LFUReplacement(ReplacementStrategy):
     def get_memory(self):
         return {}  # Plain dict is fine here
 
-    # --- OVERRIDE: Also clean up the frequency counter ---
     def delete(self, key):
-        super().delete(key)
-        if key in self.secondary_memory:
-            del self.secondary_memory[key]
+        with self.memory_lock:
+            if key in self.memory:
+                del self.memory[key]
+            if key in self.secondary_memory:
+                del self.secondary_memory[key]
 
     def clear(self):
-        super().clear()
-        self.secondary_memory.clear()
-
+        with self.memory_lock:
+            self.memory.clear()
+            self.secondary_memory.clear()
 
 # Similar changes for MFUReplacement...
 class MFUReplacement(ReplacementStrategy):

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -56,7 +56,7 @@ class TestEffiDictCRUD:
             effidict['a'] = 1
             effidict['b'] = {'data': [2, 3]}
             assert len(effidict) == 2
-            assert len(effidict.memory) == 2
+            assert len(effidict.replacement_strategy.memory) == 2
             assert len(effidict.disk_backend.keys()) == 0
 
             # READ
@@ -97,7 +97,7 @@ class TestEffiDictCRUD:
                 effidict[key] = value
 
             assert len(effidict) == num_to_add
-            assert len(effidict.memory) == max_items
+            assert len(effidict.replacement_strategy.memory) == max_items
             assert len(effidict.disk_backend.keys()) == num_to_add - max_items
 
             # READ from disk


### PR DESCRIPTION
Overview
---
This PR addresses thread-safety issues across disk backends, cache replacement strategies, and `EffiDict`, while keeping behavior largely unchanged. The focus is on preventing concurrent mutation of shared state and removing iterator state stored on the instance.

Changes
---
- Added backend-level locking to protect serialize/deserialize/delete/keys in disk backends.  
  [effidict/disk_backend.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/disk_backend.py#L18-L233)
- Enabled multithreaded SQLite access and guarded all DB operations with a lock.  By default SQLite is not thread-safe if all commits are executed with the same DB connection. A different fix would be to have a separate connection per thread.
  [effidict/disk_backend.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/disk_backend.py#L48-L96)
- Introduced `memory_lock` in `ReplacementStrategy` and wrapped all strategy mutations.  
  [effidict/replacement_strategies.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/replacement_strategies.py#L7-L51)
- During disk writes we defer eviction serialization, so no memory lock needs to be used. This trades temporal consistency for speed, but is still thread-safe.  
  [effidict/replacement_strategies.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/replacement_strategies.py#L63-L226)
- Simplified iteration to return a snapshot iterator and removed shared iterator state (removed `__next__`).  
  [effidict/effidict.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/effidict.py#L18-L20)
- Some source code in MFU implementation was duplicated, I removed it.
  [effidict/replacement_strategies.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/replacement_strategies.py#L191-L287)

Why remove `__next__`
---
The previous iterator stored `_iter_keys` on the instance, so concurrent iteration could clobber state (by replacing the _iter_keys with a new one and invalidating `__next__`). Returning `iter(self.keys())` creates a per-thread iteration, but makes `next(effidict)` not possible. 
[effidict/effidict.py](https://github.com/Szustarol/EffiDict/tree/fix-threading/effidict/effidict.py#L18-L20)

Note on Read/Write Locking (suggestion)
---
If third‑party dependencies are allowed, we consider a reader‑writer lock (RWLock) to allow concurrent reads with exclusive writes. Since reads for some replacement strategies don't modify state, this should offer speedup when used with multiple readers.



I'm happy to help with running benchmarks for performance comparison. 
