### PR TITLE
Define the target public API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 effidict/_version.py
 docs/_build
 .vscode/
+.claude/

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,6 @@ EffiDict is a fast, dictionary-like cache with pluggable on-disk backends and mu
   - Pickle folder (one pickle file per key)
   - HDF5 file (requires optional dependencies; best for numeric arrays)
 - Dict-like API: get/set, delete, `in`, `len`, `keys/items/values`, `pop`, `clear`, and iteration
-- Context manager support and explicit `close()` to release disk resources
 
 ## Installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ EffiDict is a fast, dictionary-like cache with pluggable on-disk backends and mu
   - Pickle folder (one pickle file per key)
   - HDF5 file (requires optional dependencies; best for numeric arrays)
 - Dict-like API: get/set, delete, `in`, `len`, `keys/items/values`, `pop`, `clear`, and iteration
+- Context manager support and explicit `close()` to release disk resources
 
 ## Installation
 

--- a/effidict/__init__.py
+++ b/effidict/__init__.py
@@ -1,10 +1,16 @@
 from .effidict import EffiDict
 from .disk_backend import DiskBackend, PickleBackend, Hdf5Backend, JSONBackend, SqliteBackend
+from .policies import EvictionPolicy
+from .cache import Cache
+from .store import Store
 from .replacement_strategies import ReplacementStrategy, RandomReplacement, FIFOReplacement, LIFOReplacement, LRUReplacement, MRUReplacement, LFUReplacement, MFUReplacement
 
 __all__ = [
     "EffiDict",
     "DiskBackend",
+    "EvictionPolicy",
+    "Cache",
+    "Store",
     "PickleBackend",
     "Hdf5Backend",
     "JSONBackend",

--- a/effidict/cache.py
+++ b/effidict/cache.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+
+class Cache:
+    def __init__(self, policy, max_items=None, max_bytes=None, size_estimator=None):
+        """Create a cache constrained by independent item and byte budgets.
+
+        ``max_items`` and ``max_bytes`` are independent budgets; eviction
+        happens while either budget is exceeded. ``max_bytes=None`` means
+        item-count only. ``size_estimator`` is approximate by design.
+        """
+        raise NotImplementedError("see issue #1.2")
+
+    def has(self, key) -> bool:
+        """Return whether ``key`` is present in the cache."""
+        raise NotImplementedError("see issue #1.2")
+
+    def get(self, key):
+        """Return ``key`` and record access, or raise ``KeyError`` if absent."""
+        raise NotImplementedError("see issue #1.2")
+
+    def peek(self, key):
+        """Return ``key`` without recording access, or raise ``KeyError``."""
+        raise NotImplementedError("see issue #1.2")
+
+    def put(self, key, value, dirty: bool = True) -> None:
+        """Store ``value`` under ``key`` and record dirty state."""
+        raise NotImplementedError("see issue #1.2")
+
+    def discard(self, key) -> None:
+        """Remove ``key`` if present without raising when absent."""
+        raise NotImplementedError("see issue #1.2")
+
+    def clear(self) -> None:
+        """Remove all cached entries and policy state."""
+        raise NotImplementedError("see issue #1.2")
+
+    def __len__(self) -> int:
+        """Return the number of cached items."""
+        raise NotImplementedError("see issue #1.2")
+
+    def nbytes(self) -> int:
+        """Return the approximate cached byte size."""
+        raise NotImplementedError("see issue #1.4")
+
+    def is_dirty(self, key) -> bool:
+        """Return whether ``key`` has unwritten cache changes."""
+        raise NotImplementedError("see issue #1.3")
+
+    def mark_clean(self, key) -> None:
+        """Mark ``key`` as having no unwritten cache changes."""
+        raise NotImplementedError("see issue #1.3")
+
+    def dirty_items(self) -> Iterator:
+        """Iterate over cached items with unwritten changes."""
+        raise NotImplementedError("see issue #1.3")
+
+    def evict_candidates(self) -> Iterator:
+        """Iterate over keys to shed until cache budgets are met."""
+        raise NotImplementedError("see issue #1.2")

--- a/effidict/disk_backend.py
+++ b/effidict/disk_backend.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import time
-from abc import abstractmethod
+from abc import ABC, abstractmethod
+from typing import Dict, Iterator
 import sqlite3  
 import json
 import os
@@ -14,7 +17,7 @@ except Exception:
     h5py = None
     np = None
 
-class DiskBackend:
+class DiskBackend(ABC):
     def __init__(self, storage_path):
         self.storage_path = storage_path + f"{int(time.time())}_{id(self)}"
         
@@ -41,6 +44,59 @@ class DiskBackend:
     def load_from_dict(self, dictionary):
         for key, value in dictionary.items():
             self.serialize(key, value)
+
+    def has(self, key) -> bool:
+        """Return whether ``key`` exists in this backend."""
+        raise NotImplementedError("see issue #2.2")
+
+    def count(self) -> int:
+        """Return the number of keys in this backend."""
+        raise NotImplementedError("see issue #2.2")
+
+    def iter_keys(self) -> Iterator:
+        """Iterate over keys in this backend."""
+        raise NotImplementedError("see issue #4.2")
+
+    def read_many(self, keys) -> Dict:
+        """Read multiple keys from this backend."""
+        raise NotImplementedError("see issue #4.1")
+
+    def write_many(self, items) -> None:
+        """Write multiple items to this backend."""
+        raise NotImplementedError("see issue #4.1")
+
+    def delete_many(self, keys) -> None:
+        """Delete multiple keys from this backend."""
+        raise NotImplementedError("see issue #4.1")
+
+    def compact(self) -> None:
+        """Reclaim unused storage space."""
+        raise NotImplementedError("see issue #7.2")
+
+    @classmethod
+    def create(cls, path, **kwargs):
+        """Create a new backend at ``path``."""
+        raise NotImplementedError("see issue #2.1")
+
+    @classmethod
+    def open(cls, path, mode: str = "r+", **kwargs):
+        """Open a backend at ``path``.
+
+        ``mode`` follows the ``create``/``open``/``open_or_create``
+        distinction. The existing ``__init__`` behavior of deriving a unique
+        path from the clock and ``id(self)`` is a bug fixed in issue #2.1.
+        """
+        raise NotImplementedError("see issue #2.1")
+
+    @classmethod
+    def open_or_create(cls, path, **kwargs):
+        """Open an existing backend or create one at ``path``."""
+        raise NotImplementedError("see issue #2.1")
+
+    @classmethod
+    def temporary(cls, prefix: str = "effidict-"):
+        """Create a scratch backend at a unique path."""
+        raise NotImplementedError("see issue #2.1")
 
 
 class SqliteBackend(DiskBackend):

--- a/effidict/effidict.py
+++ b/effidict/effidict.py
@@ -1,7 +1,18 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
 class EffiDict:
-    def __init__(self, disk_backend=None, replacement_strategy=None):
+    def __init__(self, disk_backend=None, replacement_strategy=None, *, max_bytes: Optional[int] = None):
+        """Create an EffiDict facade.
+
+        ``max_bytes`` is accepted as the future approximate cache byte budget,
+        but it is not enforced yet; see issue #1.4.
+        """
         self.disk_backend = disk_backend
         self.replacement_strategy = replacement_strategy
+        self.max_bytes = max_bytes
         self.memory = replacement_strategy.memory
 
     def __enter__(self):
@@ -47,6 +58,39 @@ class EffiDict:
                 return default
 
         return value
+
+    def get(self, key, default=None):
+        """Return ``key`` if present, otherwise ``default``."""
+        raise NotImplementedError("see issue #6.1")
+
+    def setdefault(self, key, default=None):
+        """Return ``key`` if present, otherwise set and return ``default``."""
+        raise NotImplementedError("see issue #6.1")
+
+    def popitem(self):
+        """Remove and return an arbitrary key/value pair."""
+        raise NotImplementedError("see issue #6.1")
+
+    def update(self, other=(), **kwargs):
+        """Update this dictionary from another mapping or iterable."""
+        raise NotImplementedError("see issue #6.1")
+
+    def iter_keys(self):
+        """Iterate over keys without materializing a list."""
+        raise NotImplementedError("see issue #4.2")
+
+    def flush(self):
+        """Flush dirty cached entries to storage."""
+        raise NotImplementedError("see issue #1.4")
+
+    def clone(self, new_path):
+        """Clone this dictionary to ``new_path``."""
+        raise NotImplementedError("see issue #3.2")
+
+    @property
+    def _store(self):
+        """Future Store facade used by white-box tier-invariant specs."""
+        raise NotImplementedError("see issue #1.2")
 
     def clear(self):
         all_keys = self.keys()

--- a/effidict/policies.py
+++ b/effidict/policies.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class EvictionPolicy(ABC):
+    """Decides which key to evict next.
+
+    A policy stores ordering and frequency metadata only; values live in
+    ``Cache``. A policy that can reach a backend is a bug.
+    """
+
+    @abstractmethod
+    def on_insert(self, key: str) -> None:
+        """Record that ``key`` was inserted."""
+        raise NotImplementedError("see issue #1.1")
+
+    @abstractmethod
+    def on_access(self, key: str) -> None:
+        """Record that ``key`` was accessed."""
+        raise NotImplementedError("see issue #1.1")
+
+    @abstractmethod
+    def on_remove(self, key: str) -> None:
+        """Forget any bookkeeping for ``key``."""
+        raise NotImplementedError("see issue #1.1")
+
+    @abstractmethod
+    def victim(self) -> str:
+        """Return the next key to evict, or raise ``KeyError`` if empty."""
+        raise NotImplementedError("see issue #1.1")
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all policy bookkeeping."""
+        raise NotImplementedError("see issue #1.1")

--- a/effidict/store.py
+++ b/effidict/store.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+
+class Store:
+    """The single owner of where a key lives.
+
+    Holds the lock. Enforces the tier invariants:
+
+    I1  Disk holds the authoritative copy of every flushed key.
+    I2  Cached entries are tagged ``clean`` (matches disk) or ``dirty``
+        (newer than disk).
+    I3  ``key in store`` is ``cache.has(key) or backend.has(key)`` --
+        never a full scan of the keyspace.
+    I4  Delete removes from cache *and* backend under one lock; no partial
+        state is observable.
+    I5  Evicting a **clean** entry is a pure memory drop with zero I/O.
+        Evicting a **dirty** entry writes *then* drops, so a key is never
+        absent from both tiers.
+    I6  A read never marks an entry dirty and never writes the key being
+        read.
+    I7  After ``flush()`` or ``close()``, every dirty entry is on disk.
+    I8  The cache honours a **byte** budget, not just an item count.
+
+    Note that keys legitimately reside in both tiers at once; I1 makes disk
+    authoritative rather than exclusive. I5 depends on that overlap.
+    """
+
+    def __init__(self, backend, cache, lock=None, owns_storage: bool = True):
+        raise NotImplementedError("see issue #1.2")
+
+    @property
+    def backend(self):
+        """Return the backing persistent store."""
+        raise NotImplementedError("see issue #1.2")
+
+    @property
+    def cache(self):
+        """Return the in-memory cache."""
+        raise NotImplementedError("see issue #1.2")
+
+    @property
+    def owns_storage(self) -> bool:
+        """Return whether this store owns the backend storage lifecycle."""
+        raise NotImplementedError("see issue #3.1")
+
+    def get(self, key):
+        """Return ``key`` from the store."""
+        raise NotImplementedError("see issue #1.2")
+
+    def set(self, key, value) -> None:
+        """Store ``value`` under ``key``."""
+        raise NotImplementedError("see issue #1.2")
+
+    def delete(self, key) -> None:
+        """Remove ``key`` from all tiers."""
+        raise NotImplementedError("see issue #1.2")
+
+    def pop(self, key, default=None):
+        """Remove ``key`` and return its value, or ``default`` if absent."""
+        raise NotImplementedError("see issue #1.2")
+
+    def clear(self) -> None:
+        """Remove all entries from all tiers."""
+        raise NotImplementedError("see issue #1.2")
+
+    def update(self, items) -> None:
+        """Store multiple items."""
+        raise NotImplementedError("see issue #4.1")
+
+    def contains(self, key) -> bool:
+        """Return whether ``key`` is present in any tier."""
+        raise NotImplementedError("see issue #1.2")
+
+    def count(self) -> int:
+        """Return the number of distinct keys in the store."""
+        raise NotImplementedError("see issue #1.2")
+
+    def iter_keys(self) -> Iterator:
+        """Iterate over all distinct keys in the store."""
+        raise NotImplementedError("see issue #4.2")
+
+    def in_cache(self, key) -> bool:
+        """White-box hook for tier-invariant specs to assert preconditions."""
+        raise NotImplementedError("see issue #1.2")
+
+    def flush(self) -> None:
+        """Write dirty cached items to the backend."""
+        raise NotImplementedError("see issue #1.4")
+
+    def close(self) -> None:
+        """Close store resources without destroying storage."""
+        raise NotImplementedError("see issue #1.2")
+
+    def destroy(self) -> None:
+        """Destroy owned storage resources."""
+        raise NotImplementedError("see issue #3.1")
+
+    def clone(self, new_path):
+        """Clone the store to ``new_path``."""
+        raise NotImplementedError("see issue #3.2")


### PR DESCRIPTION
Closes #22

First PR of the 1.0 refactor. Interface only — signatures and docstrings, no behaviour, no refactor, no bug fixes.

## Why

The next nine PRs write a test suite specifying the target behaviour of `EffiDict`. Those specs reference classes and methods that do not exist yet. Without this PR they would fail with `AttributeError` ("typo or wrong name?") instead of `NotImplementedError` ("not built yet, see issue #N") — two very different signals to a reviewer.

## What's here

- New `EvictionPolicy` ABC (`policies.py`) — pure bookkeeping contract: no values, no I/O, no backend reference.
- New `Cache` and `Store` contracts (`cache.py`, `store.py`). `Store`'s docstring carries the eight tier invariants it will own.
- `DiskBackend` becomes a real ABC, plus `has`, `count`, `iter_keys`, `read_many`, `write_many`, `delete_many`, `compact` and the `create`/`open`/`open_or_create`/`temporary` classmethods.
- `EffiDict` gains `get`, `setdefault`, `popitem`, `update`, `iter_keys`, `flush`, `clone`, a `_store` hook for the white-box specs, and a keyword-only `max_bytes` (accepted and stored, not enforced until #1.4).

Every `NotImplementedError` names the issue that will implement it.

## Note on the ABC change

`DiskBackend` previously carried `@abstractmethod` decorators with no `ABCMeta`, so they were inert. Making it a real ABC means the five already-implemented methods (`serialize`, `deserialize`, `del_item`, `keys`, `destroy`) are now genuinely abstract, while every new method is **concrete** with a `NotImplementedError` body — marking those abstract would break all four backends at construction.
