### PR TITLE
23 02 test harness fixtures backend policy matrix leak detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,7 @@ jobs:
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install coverage
-        pip install h5py
-        pip install -e .
+        pip install -e ".[dev]"
 
     - name: Test with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ effidict/_version.py
 docs/_build
 .vscode/
 .claude/
+.coverage
+coverage.xml
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,24 @@ classifiers = [
 
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = [
+    "pytest",
+    "hypothesis",
+    "pandas",
+    "numpy",
+    "h5py",
+    "joblib",
+    "coverage",
+]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+testpaths = ["tests"]
+markers = [
+    "slow: long-running guard; skip locally with -m 'not slow', always run in CI",
+    "stress: repeated or concurrent; always run in CI",
+    "keeps_storage: opts out of the storage-leak detector (storage outlives the test)",
+]
 
 [project.urls]
 documentation = "https://oligo-designer-toolsuite.readthedocs.io/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,266 @@
+"""Shared harness for the Phase 0 specification suite.
+
+Provides:
+
+``backend_cls`` / ``policy_cls``
+    Parametrized fixtures giving the 4 x 7 = 28 backend/policy matrix.
+``make_dict``
+    Factory for an ``EffiDict`` wired to a temp store, registered for teardown.
+``backend_spy``
+    Records backend method calls. Most non-functional guards count calls rather
+    than measure time, so this lives here rather than in individual specs.
+autouse leak detector
+    Releases every store the test created, then asserts the storage directory is
+    empty. Anything left behind is a library-level leak.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from effidict import (
+    EffiDict,
+    FIFOReplacement,
+    Hdf5Backend,
+    JSONBackend,
+    LFUReplacement,
+    LIFOReplacement,
+    LRUReplacement,
+    MFUReplacement,
+    MRUReplacement,
+    PickleBackend,
+    RandomReplacement,
+    SqliteBackend,
+)
+
+try:
+    import h5py
+except ImportError:  # pragma: no cover - h5py is a dev dependency
+    h5py = None
+
+# `pytester` lets the harness test itself in a subprocess-like sandbox, which is
+# how the leak detector proves it actually fires.
+pytest_plugins = ["pytester"]
+
+BACKENDS = [SqliteBackend, PickleBackend, JSONBackend, Hdf5Backend]
+
+POLICIES = [
+    RandomReplacement,
+    FIFOReplacement,
+    LIFOReplacement,
+    LRUReplacement,
+    MRUReplacement,
+    LFUReplacement,
+    MFUReplacement,
+]
+
+#: Used when a test asks for `make_dict` without joining the matrix. Pickle
+#: accepts every value kind and LRU is the most common policy, so an
+#: unparametrized test exercises the least surprising combination.
+DEFAULT_BACKEND = PickleBackend
+DEFAULT_POLICY = LRUReplacement
+
+
+def _backend_param(backend_cls):
+    marks = []
+    if backend_cls is Hdf5Backend:
+        marks.append(pytest.mark.skipif(h5py is None, reason="h5py is not installed"))
+    return pytest.param(backend_cls, id=backend_cls.__name__, marks=marks)
+
+
+@pytest.fixture(params=[_backend_param(cls) for cls in BACKENDS])
+def backend_cls(request):
+    """One disk backend class per parametrization."""
+    return request.param
+
+
+@pytest.fixture(params=POLICIES, ids=[cls.__name__ for cls in POLICIES])
+def policy_cls(request):
+    """One replacement policy class per parametrization.
+
+    Named ``policy`` rather than ``strategy`` for the post-1.1 API; it currently
+    receives the ``*Replacement`` classes.
+    """
+    return request.param
+
+
+@pytest.fixture
+def storage_dir(tmp_path):
+    """Directory that must be empty once the test has released its stores."""
+    path = tmp_path / "effidict-storage"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def _open_stores():
+    return []
+
+
+@pytest.fixture(autouse=True)
+def storage_leak_detector(request, storage_dir, _open_stores):
+    """Release the test's stores, then assert nothing was left on disk.
+
+    Releasing first is deliberate. It means a surviving file is a *library*
+    defect -- ``destroy()`` failing to remove everything, or ``close()`` failing
+    to flush -- rather than a test that merely forgot to call cleanup.
+
+    Mark a test ``keeps_storage`` to skip the assertion; issue 0.5's
+    close-then-reopen specs need storage to outlive a close.
+    """
+    yield
+
+    for store in reversed(_open_stores):
+        _release(store)
+
+    if request.node.get_closest_marker("keeps_storage"):
+        return
+
+    leaked = sorted(p.name for p in storage_dir.iterdir())
+    assert not leaked, f"storage left behind in {storage_dir}: {leaked}"
+
+
+def _release(store):
+    """Best-effort teardown that survives the pre-3.1 lifecycle semantics.
+
+    ``destroy()`` is preferred once it exists (issue 3.1); today ``close()`` is
+    what removes storage. ``FileNotFoundError`` is tolerated narrowly because
+    ``destroy()`` is not yet idempotent -- a known defect tracked in 3.1. Any
+    other exception propagates rather than being swallowed.
+    """
+    for name in ("destroy", "close"):
+        method = getattr(store, name, None)
+        if method is None:
+            continue
+        try:
+            method()
+        except NotImplementedError:
+            # Not built yet -- fall through and try the next mechanism rather
+            # than reporting success, or storage would silently survive.
+            continue
+        except FileNotFoundError:
+            # destroy() is not yet idempotent (issue 3.1); a second release of
+            # the same storage is expected today.
+            pass
+        return
+
+
+@pytest.fixture
+def make_dict(request, storage_dir, _open_stores):
+    """Build an ``EffiDict`` over a fresh temp store.
+
+    Resolves ``backend``/``policy`` from the active matrix fixtures when the test
+    is parametrized, otherwise falls back to ``DEFAULT_BACKEND``/``DEFAULT_POLICY``.
+    """
+    counter = {"n": 0}
+
+    def factory(backend=None, policy=None, max_in_memory=2, max_bytes=None, **kwargs):
+        if backend is None:
+            backend = (
+                request.getfixturevalue("backend_cls")
+                if "backend_cls" in request.fixturenames
+                else DEFAULT_BACKEND
+            )
+        if policy is None:
+            policy = (
+                request.getfixturevalue("policy_cls")
+                if "policy_cls" in request.fixturenames
+                else DEFAULT_POLICY
+            )
+
+        path = storage_dir / f"{backend.__name__}-{counter['n']}"
+        counter["n"] += 1
+
+        disk_backend = backend(str(path))
+        _open_stores.append(disk_backend)
+
+        effidict = EffiDict(
+            disk_backend=disk_backend,
+            replacement_strategy=policy(
+                disk_backend=disk_backend, max_in_memory=max_in_memory
+            ),
+            # Passed unconditionally: silently dropping it would let issue 0.4's
+            # byte-budget spec pass a budget that never arrives.
+            max_bytes=max_bytes,
+            **kwargs,
+        )
+        _open_stores.append(effidict)
+        return effidict
+
+    return factory
+
+
+@pytest.fixture
+def backend_spy():
+    """Context manager recording every public method call on a backend."""
+
+    @contextlib.contextmanager
+    def factory(backend):
+        spy = BackendSpy(backend)
+        with spy:
+            yield spy
+
+    return factory
+
+
+class BackendSpy:
+    """Records calls to a backend instance's public methods.
+
+    Wraps bound methods with instance attributes and deletes them on exit, so
+    the class is never mutated and nothing leaks between tests. Classmethods
+    (``create``/``open``/``temporary``) are left alone -- patching those on an
+    instance is fragile and no spec needs it.
+    """
+
+    def __init__(self, backend):
+        self.backend = backend
+        self.calls = []
+        self._counts = {}
+        self._patched = []
+
+    def __enter__(self):
+        for name in self._method_names():
+            original = getattr(self.backend, name)
+            setattr(self.backend, name, self._wrap(name, original))
+            self._patched.append(name)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        for name in reversed(self._patched):
+            delattr(self.backend, name)
+        self._patched.clear()
+        return False
+
+    def count(self, name):
+        """How many times ``name`` was called since entry or the last reset."""
+        return self._counts.get(name, 0)
+
+    def names(self):
+        """Method names that were called at least once."""
+        return sorted(name for name, n in self._counts.items() if n)
+
+    def reset(self):
+        self.calls.clear()
+        self._counts.clear()
+
+    def _method_names(self):
+        names = set()
+        for klass in type(self.backend).__mro__:
+            for name, attr in vars(klass).items():
+                if name.startswith("_"):
+                    continue
+                if isinstance(attr, (staticmethod, classmethod, property)):
+                    continue
+                if callable(attr):
+                    names.add(name)
+        return sorted(names)
+
+    def _wrap(self, name, original):
+        def recorder(*args, **kwargs):
+            self.calls.append((name, args, dict(kwargs)))
+            self._counts[name] = self._counts.get(name, 0) + 1
+            return original(*args, **kwargs)
+
+        return recorder

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,147 @@
+"""Value catalogue and comparison helper shared by every Phase 0 spec.
+
+The per-backend tables below were derived by round-tripping each value through
+each backend, not by reading the source. Anything asserted here is observed
+behaviour on ``main``; ``test_harness.py`` re-derives the tables on every run so
+they cannot drift.
+"""
+
+from __future__ import annotations
+
+import math
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - numpy is a dev dependency
+    np = None
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - pandas is a dev dependency
+    pd = None
+
+from effidict import Hdf5Backend, JSONBackend, PickleBackend, SqliteBackend
+
+
+def _ndarray():
+    if np is None:  # pragma: no cover
+        raise RuntimeError("numpy is required for the 'ndarray' value kind")
+    return np.ones(4)
+
+
+def _dataframe():
+    if pd is None:  # pragma: no cover
+        raise RuntimeError("pandas is required for the 'dataframe' value kind")
+    return pd.DataFrame({"a": [1, 2]})
+
+
+#: Every value shape the specs exercise. Includes the shapes that broke in
+#: production: ``None``, ``{}``, nested dicts and DataFrames.
+VALUE_KINDS = {
+    "int": lambda: 7,
+    "float": lambda: 1.5,
+    "bool": lambda: True,
+    "str": lambda: "hello",
+    "none": lambda: None,
+    "empty_dict": lambda: {},
+    "dict": lambda: {"a": 1},
+    "nested_dict": lambda: {"a": {"b": [1, 2]}},
+    "list": lambda: [1, 2, 3],
+    "tuple": lambda: (1, 2),
+    "ndarray": _ndarray,
+    "dataframe": _dataframe,
+}
+
+#: Kinds a backend refuses outright. Writing one of these raises.
+UNSUPPORTED = {
+    SqliteBackend: {"ndarray", "dataframe"},
+    JSONBackend: {"ndarray", "dataframe"},
+    PickleBackend: set(),
+    Hdf5Backend: set(),
+}
+
+#: Kinds a backend accepts but does not round-trip faithfully. These are
+#: DEFECTS, deliberately kept separate from UNSUPPORTED: folding them together
+#: would let the specs skip them, and a silently-wrong round-trip is exactly
+#: what issue 0.8 (`test_value_roundtrip_fidelity`) has to assert on.
+#:
+#:   * SQLite/JSON encode via JSON, so a tuple returns as a list.
+#:   * HDF5 widens Python scalars to numpy scalars (int -> int64, bool -> bool_).
+#:   * HDF5 converts a numeric DataFrame to an array, so the write succeeds and
+#:     the value comes back as an ndarray.
+LOSSY = {
+    SqliteBackend: {"tuple"},
+    JSONBackend: {"tuple"},
+    PickleBackend: set(),
+    Hdf5Backend: {"int", "float", "bool", "dataframe"},
+}
+
+
+def supported_kinds(backend_cls):
+    """Kinds that round-trip faithfully through ``backend_cls``."""
+    return set(VALUE_KINDS) - UNSUPPORTED[backend_cls] - LOSSY[backend_cls]
+
+
+def is_unsupported(backend_cls, kind):
+    return kind in UNSUPPORTED[backend_cls]
+
+
+def is_lossy(backend_cls, kind):
+    return kind in LOSSY[backend_cls]
+
+
+def assert_equal_value(actual, expected):
+    """Assert two stored values are equal, handling arrays and DataFrames.
+
+    Type-strict by design: ``1`` is not ``True`` and ``numpy.int64(7)`` is not
+    ``7``. Plain ``==`` conflates all three, which would hide the HDF5 scalar
+    widening and the SQLite tuple-to-list conversion recorded in ``LOSSY``.
+    """
+    if not _equal(actual, expected):
+        raise AssertionError(
+            f"values differ:\n  actual   {type(actual).__name__}: {actual!r}"
+            f"\n  expected {type(expected).__name__}: {expected!r}"
+        )
+
+
+def _equal(actual, expected):
+    if _is_nan(actual) and _is_nan(expected):
+        return True
+
+    if pd is not None:
+        frame_types = (pd.DataFrame, pd.Series)
+        if isinstance(actual, frame_types) or isinstance(expected, frame_types):
+            if type(actual) is not type(expected):
+                return False
+            return actual.equals(expected)
+
+    if np is not None:
+        if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+            if not (isinstance(actual, np.ndarray) and isinstance(expected, np.ndarray)):
+                return False
+            # equal_nan calls isnan(), which raises TypeError on string and
+            # object dtypes, so only ask for it where NaN can exist.
+            if np.issubdtype(actual.dtype, np.inexact) and np.issubdtype(
+                expected.dtype, np.inexact
+            ):
+                return np.array_equal(actual, expected, equal_nan=True)
+            return np.array_equal(actual, expected)
+
+    if type(actual) is not type(expected):
+        return False
+
+    if isinstance(expected, dict):
+        if set(actual) != set(expected):
+            return False
+        return all(_equal(actual[key], expected[key]) for key in expected)
+
+    if isinstance(expected, (list, tuple)):
+        if len(actual) != len(expected):
+            return False
+        return all(_equal(a, e) for a, e in zip(actual, expected))
+
+    return actual == expected
+
+
+def _is_nan(value):
+    return isinstance(value, float) and math.isnan(value)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,328 @@
+"""Tests for the harness itself.
+
+The harness is load-bearing for every other Phase 0 spec, so it is verified
+rather than assumed. In particular the leak detector is proved to fail on a
+deliberate leak -- an autouse fixture that never fires is worse than no fixture.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from .conftest import BACKENDS, POLICIES
+from .helpers import (
+    UNSUPPORTED,
+    VALUE_KINDS,
+    assert_equal_value,
+    is_lossy,
+    is_unsupported,
+    supported_kinds,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install_harness(pytester):
+    """Point a pytester sandbox at this repo's conftest."""
+    pytester.makeconftest(
+        "\n".join(
+            [
+                "import sys",
+                f"sys.path.insert(0, {str(PROJECT_ROOT)!r})",
+                'pytest_plugins = ["tests.conftest"]',
+            ]
+        )
+    )
+
+
+# --------------------------------------------------------------------------
+# matrix
+# --------------------------------------------------------------------------
+
+
+def test_matrix_collects_28_combinations(pytester):
+    """Exercise real pytest collection.
+
+    Asserting ``len(BACKENDS) * len(POLICIES) == 28`` in Python would pass even
+    if the backend_cls/policy_cls fixtures were broken, which is the thing under
+    test. So run a sub-pytest and count what actually ran.
+    """
+    _install_harness(pytester)
+    pytester.makepyfile(
+        """
+        def test_combo(backend_cls, policy_cls):
+            assert backend_cls is not None and policy_cls is not None
+        """
+    )
+
+    result = pytester.runpytest("-q")
+
+    outcomes = result.parseoutcomes()
+    # h5py-conditional params skip rather than vanish, so the total is fixed.
+    assert outcomes.get("passed", 0) + outcomes.get("skipped", 0) == 28
+    assert outcomes.get("failed", 0) == 0
+    assert outcomes.get("errors", 0) == 0
+
+
+def test_matrix_ids_are_readable_and_unique(pytester):
+    _install_harness(pytester)
+    pytester.makepyfile(
+        """
+        def test_combo(backend_cls, policy_cls):
+            pass
+        """
+    )
+
+    result = pytester.runpytest("--collect-only", "-q")
+
+    lines = [line for line in result.outlines if "test_combo[" in line]
+    assert len(lines) == 28
+    assert len(set(lines)) == 28
+    assert any("[SqliteBackend-LRUReplacement]" in line for line in lines)
+
+
+# --------------------------------------------------------------------------
+# make_dict
+# --------------------------------------------------------------------------
+
+
+def test_make_dict_roundtrips_across_the_matrix(backend_cls, policy_cls, make_dict):
+    d = make_dict()
+
+    d["a"] = {"nested": [1, 2]}
+
+    assert_equal_value(d["a"], {"nested": [1, 2]})
+
+
+def test_make_dict_honours_max_in_memory(make_dict):
+    d = make_dict(max_in_memory=2)
+
+    for key in ("a", "b", "c"):
+        d[key] = key
+
+    assert len(d.replacement_strategy.memory) == 2
+    assert len(d.keys()) == 3
+
+
+def test_make_dict_forwards_max_bytes(make_dict):
+    """A dropped max_bytes would let issue 0.4's budget spec test nothing."""
+    d = make_dict(max_bytes=4096)
+
+    assert d.max_bytes == 4096
+
+
+def test_make_dict_defaults_when_unparametrized(make_dict):
+    from .conftest import DEFAULT_BACKEND, DEFAULT_POLICY
+
+    d = make_dict()
+
+    assert isinstance(d.disk_backend, DEFAULT_BACKEND)
+    assert isinstance(d.replacement_strategy, DEFAULT_POLICY)
+
+
+def test_make_dict_gives_each_dict_its_own_storage(make_dict):
+    first = make_dict()
+    second = make_dict()
+
+    assert first.disk_backend.storage_path != second.disk_backend.storage_path
+
+
+# --------------------------------------------------------------------------
+# leak detector
+# --------------------------------------------------------------------------
+
+
+def test_leak_detector_fires_on_a_leaked_file(pytester):
+    """The acceptance criterion: prove the detector actually fails."""
+    _install_harness(pytester)
+    pytester.makepyfile(
+        """
+        def test_leaks(storage_dir):
+            (storage_dir / "leaked.bin").write_bytes(b"x")
+        """
+    )
+
+    result = pytester.runpytest("-q")
+
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(["*storage left behind*leaked.bin*"])
+
+
+def test_leak_detector_passes_when_storage_is_released(pytester):
+    _install_harness(pytester)
+    pytester.makepyfile(
+        """
+        def test_clean(make_dict):
+            d = make_dict()
+            d["a"] = 1
+        """
+    )
+
+    result = pytester.runpytest("-q")
+
+    result.assert_outcomes(passed=1)
+
+
+def test_keeps_storage_marker_opts_out(pytester):
+    """Issue 0.5 needs storage to outlive a close, so the opt-out must work."""
+    _install_harness(pytester)
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.keeps_storage
+        def test_deliberately_keeps(storage_dir):
+            (storage_dir / "kept.bin").write_bytes(b"x")
+        """
+    )
+
+    result = pytester.runpytest("-q")
+
+    result.assert_outcomes(passed=1)
+
+
+# --------------------------------------------------------------------------
+# assert_equal_value
+# --------------------------------------------------------------------------
+
+
+def test_assert_equal_value_handles_arrays_frames_and_nan():
+    pytest.importorskip("numpy")
+    pytest.importorskip("pandas")
+
+    left = {"nan": float("nan"), "nested": [VALUE_KINDS["ndarray"]()]}
+    right = {"nan": float("nan"), "nested": [VALUE_KINDS["ndarray"]()]}
+
+    assert_equal_value(left, right)
+    assert_equal_value(VALUE_KINDS["dataframe"](), VALUE_KINDS["dataframe"]())
+
+
+def test_assert_equal_value_handles_string_arrays():
+    """equal_nan=True raises TypeError on non-numeric dtypes if not guarded."""
+    np = pytest.importorskip("numpy")
+
+    assert_equal_value(np.array(["a", "b"]), np.array(["a", "b"]))
+    with pytest.raises(AssertionError):
+        assert_equal_value(np.array(["a", "b"]), np.array(["a", "c"]))
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        ({"a": [1, 2, 3]}, {"a": [1, 2, 4]}),
+        (1, True),  # plain == conflates these
+        (1, 1.0),
+        ((1, 2), [1, 2]),  # the SQLite/JSON tuple defect
+        ({"a": 1}, {"a": 1, "b": 2}),
+    ],
+)
+def test_assert_equal_value_is_type_strict(left, right):
+    with pytest.raises(AssertionError):
+        assert_equal_value(left, right)
+
+
+def test_assert_equal_value_rejects_numpy_scalar_widening():
+    """The HDF5 int -> int64 defect must not compare equal."""
+    np = pytest.importorskip("numpy")
+
+    with pytest.raises(AssertionError):
+        assert_equal_value(np.int64(7), 7)
+
+
+# --------------------------------------------------------------------------
+# value support tables
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", list(VALUE_KINDS))
+def test_value_support_tables_match_reality(backend_cls, kind, tmp_path):
+    """Re-derive UNSUPPORTED/LOSSY every run so the tables cannot go stale."""
+    if kind == "ndarray":
+        pytest.importorskip("numpy")
+    if kind == "dataframe":
+        pytest.importorskip("pandas")
+
+    backend = backend_cls(str(tmp_path / backend_cls.__name__))
+    value = VALUE_KINDS[kind]()
+
+    try:
+        if is_unsupported(backend_cls, kind):
+            with pytest.raises(TypeError):
+                backend.serialize("k", value)
+            return
+
+        backend.serialize("k", value)
+        actual = backend.deserialize("k")
+
+        if is_lossy(backend_cls, kind):
+            with pytest.raises(AssertionError):
+                assert_equal_value(actual, value)
+        else:
+            assert_equal_value(actual, value)
+    finally:
+        with contextlib.suppress(Exception):
+            backend.destroy()
+
+
+def test_support_tables_partition_every_kind():
+    for backend_cls in BACKENDS:
+        buckets = (
+            supported_kinds(backend_cls),
+            UNSUPPORTED[backend_cls],
+            set(k for k in VALUE_KINDS if is_lossy(backend_cls, k)),
+        )
+        union = set().union(*buckets)
+        assert union == set(VALUE_KINDS), backend_cls.__name__
+        assert sum(len(b) for b in buckets) == len(VALUE_KINDS), backend_cls.__name__
+
+
+# --------------------------------------------------------------------------
+# backend spy
+# --------------------------------------------------------------------------
+
+
+def test_backend_spy_records_and_delegates(make_dict, backend_spy):
+    d = make_dict(max_in_memory=1)
+    d["a"] = 1
+    d["b"] = 2  # forces 'a' out to disk
+
+    with backend_spy(d.disk_backend) as spy:
+        assert d["a"] == 1
+        assert spy.count("deserialize") == 1
+        assert spy.count("del_item") == 0
+        assert spy.calls[0][0] == "deserialize"
+
+        spy.reset()
+        assert spy.calls == []
+        assert spy.count("deserialize") == 0
+
+
+def test_backend_spy_restores_the_backend(make_dict, backend_spy):
+    d = make_dict()
+    original = type(d.disk_backend).serialize
+
+    with backend_spy(d.disk_backend):
+        assert d.disk_backend.serialize.__name__ == "recorder"
+
+    assert d.disk_backend.serialize.__func__ is original
+    assert "serialize" not in vars(d.disk_backend)
+
+
+def test_backend_spy_leaves_classmethods_alone(make_dict, backend_spy):
+    d = make_dict()
+
+    with backend_spy(d.disk_backend) as spy:
+        assert "create" not in spy._patched
+        assert "open" not in spy._patched
+
+
+def test_backend_spy_counts_writes_during_eviction(make_dict, backend_spy):
+    d = make_dict(max_in_memory=1)
+
+    with backend_spy(d.disk_backend) as spy:
+        d["a"] = 1
+        d["b"] = 2
+        assert spy.count("serialize") == 1


### PR DESCRIPTION
Closes #23. 

Scaffolding the remaining eight Phase 0 spec PRs build on. No production code changes.

## What's here

- `tests/conftest.py` — `backend_cls` / `policy_cls` matrix fixtures (4 x 7 = 28), a `make_dict` factory, the storage-leak detector, and `backend_spy`.
- `tests/helpers.py` — `assert_equal_value` plus the value catalogue and the per-backend support tables.
- `tests/test_harness.py` — 98 tests verifying the harness itself.
- `pyproject.toml` — dev extras, registered markers (`slow`, `stress`, `keeps_storage`), `--strict-markers`.
- `.github/workflows/test.yml` — four `pip install` lines collapse to `pip install -e ".[dev]"`. 

## Verification

- 154 tests pass (56 existing + 98 new).
- The 28-combination matrix collects and runs: `28 tests collected`, `28 passed`.

## Decisions worth a look

**The leak detector proof is permanent, not manual.** The acceptance criterion asked to prove it fires and then remove the proof; `test_leak_detector_fires_on_a_leaked_file` instead runs a sub-pytest via `pytester` that leaks a file and asserts the run fails. An autouse fixture that silently stops firing is worse than no fixture, and every later spec PR depends on this one.

**It releases stores first, then asserts.** So a surviving file means a *library* defect — `destroy()` not removing everything, `close()` not flushing — rather than a test that forgot cleanup. `keeps_storage` opts out, which #0.5's close-then-reopen specs will need.

**`assert_equal_value` is type-strict.** `1` is not `True`, `1.0` is not `1`, `(1, 2)` is not `[1, 2]`, `numpy.int64(7)` is not `7`. Plain `==` accepts all four, which would hide the exact defects #0.8 exists to catch.

**`max_bytes` is forwarded unconditionally** — no capability probe. If `EffiDict` ever stops accepting it that is a loud `TypeError`, rather than #0.4's byte-budget spec silently receiving no budget.